### PR TITLE
Bump some deps + cross Scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ lazy val core = Project("stringmetric-core", file("core"))
 	.settings(Settings.commonSettings)
 	.settings(
 		libraryDependencies ++= Seq(
-			"org.specs2" %% "specs2-core" % "4.0.2-291bdf5-20171123131811" % "test",
-			"org.specs2" %% "specs2-junit" % "4.0.2-291bdf5-20171123131811" % Test
+			"org.specs2" %% "specs2-core" % "4.0.4" % "test",
+			"org.specs2" %% "specs2-junit" % "4.0.4" % Test
 		)
 	)
 
@@ -20,8 +20,8 @@ lazy val cli = Project("stringmetric-cli", file("cli"))
 	.settings(Settings.commonSettings)
 	.settings(
 		libraryDependencies ++= Seq(
-			"org.specs2" %% "specs2-core" % "4.0.2-291bdf5-20171123131811" % "test",
-			"org.specs2" %% "specs2-junit" % "4.0.2-291bdf5-20171123131811" % Test
+			"org.specs2" %% "specs2-core" % "4.0.4" % "test",
+			"org.specs2" %% "specs2-junit" % "4.0.4" % Test
 		)
 	)
 	.dependsOn(core)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.1.4

--- a/project/commons.scala
+++ b/project/commons.scala
@@ -7,7 +7,8 @@ object Settings {
 	val commonSettings: Seq[Def.Setting[_]] = Seq(
 		organization := "com.mnemotix",
 		homepage := Some(url("https://rockymadden.com/stringmetric/")),
-		scalaVersion := "2.12.4",
+		scalaVersion := "2.12.6",
+		crossScalaVersions := Seq("2.11.12", "2.12.6"),
 		scalacOptions ++= Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-Xlint"),
 		licenses := Seq("Apache 2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
 		developers := List(


### PR DESCRIPTION
This allows to have the build cross-compile with Scala 2.11 and 2.12, using the "+" sbt modifier (e.g. `sbt +test`)

By the way, SBT and Scala have been updated.

specs2 has been updated to the next crossed-compiled version.